### PR TITLE
fix(editor): show widgets outside container

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8"/>
   <link rel="icon" type="image/svg+xml" href="/favicon.ico"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Pillarbox Theme Edito</title>
+  <title>Pillarbox Theme Editor</title>
   <link rel="stylesheet" href="scss/index.scss"/>
   <script type="module" src="./src/index.js"></script>
 </head>

--- a/src/components/css-editor.js
+++ b/src/components/css-editor.js
@@ -121,6 +121,7 @@ class CssEditor extends LitElement {
       language: 'css',
       theme: this.getTheme(),
       automaticLayout: true,
+      fixedOverflowWidgets: true,
       minimap: { enabled: false }
     });
 


### PR DESCRIPTION
## Description

Resolves an issue where widgets and context menus were being cut off when they extended outside the Editor's container by enabling fixedOverflowWidgets.

Refs: https://github.com/microsoft/monaco-editor/issues/1203

## Changes Made

- Set `fixedOverflowWidgets` to `true`.
- Fixed a typo in the page title.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
