### PR TITLE
feat: allow media source swapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
 <main>
   <resizable-split-view>
     <section slot="left">
-      <div class="craft-title-container">
+      <div class="section-title-container">
         <h2>Craft your theme</h2>
         <toggle-pane-button title="Select a file to edit" id="navigation-button">
           <tree-view id="navigation"></tree-view>
@@ -31,7 +31,12 @@
       <css-editor id="editor"></css-editor>
     </section>
     <section slot="right">
-      <h2>Live Canvas Preview</h2>
+      <div class="section-title-container">
+        <h2>Live Canvas Preview</h2>
+        <toggle-pane-button title="Change the media" label="Change the media" id="load-media-button">
+          <input id="src-input" type="text" placeholder="Enter a URN..." />
+        </toggle-pane-button>
+      </div>
       <preview-box id="preview"></preview-box>
     </section>
   </resizable-split-view>

--- a/scss/index.scss
+++ b/scss/index.scss
@@ -7,11 +7,11 @@
 }
 
 :root {
-  color: rgb(255 255 255 / 87%);
+  color: var(--app-color);
   font-weight: 400;
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
-  background-color: #242424;
+  background-color: var(--app-background-color);
   font-synthesis: none;
   text-rendering: optimizelegibility;
   -webkit-font-smoothing: antialiased;
@@ -19,8 +19,10 @@
 
   --button-background: #40729d;
   --button-hover-background: #305273;
-  --button-color: #fff;
+  --button-color: var(--app-color);
   --button-border-radius: 0.5em;
+  --app-background-color: #242424;
+  --app-color: rgb(255 255 255 / 87%);
 }
 
 html,
@@ -54,7 +56,7 @@ header p {
   margin-left: 0.5em;
   padding-left: 0.5em;
   text-align: justify;
-  border-left: 3px solid rgb(255 255 255 / 87%);
+  border-left: 3px solid var(--app-color)
 }
 
 main {
@@ -86,7 +88,7 @@ footer {
   }
 }
 
-.craft-title-container {
+.section-title-container {
   display: flex;
   gap: 1em;
   align-items: center;
@@ -117,4 +119,14 @@ footer {
 
 #download:hover {
   background-color: var(--button-hover-background);
+}
+
+input {
+  margin: 0;
+  padding: 0.5em 0.2em;
+  color: var(--app-color);
+  font-size: var(--size-3);
+  background-color: var(--app-background-color);
+  border: none;
+  outline: none;
 }

--- a/src/components/preview-box.js
+++ b/src/components/preview-box.js
@@ -1,5 +1,4 @@
 import { html, LitElement } from 'lit';
-import { createRef, ref } from 'lit/directives/ref.js';
 import pillarbox from '@srgssr/pillarbox-web';
 
 /**
@@ -10,49 +9,54 @@ import pillarbox from '@srgssr/pillarbox-web';
  * @element preview-box
  *
  * @property {String} appliedCss CSS styles that can be applied to the video player.
+ * @property {String} [src='urn:rts:video:14318206'] The media to be loaded by the player,
+ * @property {String} [type='srgssr/urn'] The type of media to be loaded.
  *
  * @example
  * <preview-box></preview-box>
  */
 class PreviewBox extends LitElement {
   static properties = {
-    appliedCss: { type: String }
+    appliedCss: { type: String },
+    src: { type: String },
+    type: { type: String }
   };
 
   constructor() {
     super();
-    this.pillarboxRef = createRef();
+    this.src = 'urn:rts:video:14318206';
+    this.type = 'srgssr/urn';
   }
 
-  /**
-   * Renders the video player with applied custom CSS and the pillarbox library functionalities.
-   *
-   * @returns {TemplateResult} The LitElement `html` template result.
-   */
   render() {
     return html`
       <style>${this.appliedCss}</style>
-      <video id="main-player"
+      <video id="preview-player"
              class="pillarbox-js"
-             controls crossOrigin="anonymous"
-             ${ref(this.pillarboxRef)}>
+             controls crossOrigin="anonymous">
       </video>
     `;
   }
 
-  /**
-   * Lifecycle callback that is called after the component's first render.
-   * It initializes the pillarbox player with a specific video source.
-   */
-  firstUpdated(_changedProperties) {
+  updated(_changedProperties) {
     super.firstUpdated(_changedProperties);
 
-    // Initializes pillarbox with the video element and sets the video source.
-    this.player = pillarbox(this.pillarboxRef.value, { muted: true });
-    this.player.src({
-      src: 'urn:rts:video:14318206',
-      type: 'srgssr/urn'
-    });
+    if (['src', 'type'].some(property => _changedProperties.has(property))) {
+      this.player?.dispose();
+
+      const el = this.shadowRoot.getElementById('preview-player');
+
+      this.player = pillarbox(el, {
+        muted: true,
+        restoreEl: true
+      });
+
+      this.player.src({
+        src: this.src,
+        type: this.type,
+        disableTrackers: true
+      });
+    }
   }
 }
 

--- a/src/components/preview-box.js
+++ b/src/components/preview-box.js
@@ -1,4 +1,4 @@
-import { html, LitElement } from 'lit';
+import { css, html, LitElement } from 'lit';
 import pillarbox from '@srgssr/pillarbox-web';
 
 /**
@@ -18,30 +18,40 @@ import pillarbox from '@srgssr/pillarbox-web';
 class PreviewBox extends LitElement {
   static properties = {
     appliedCss: { type: String },
-    src: { type: String },
+    mediaSrc: { type: String },
     type: { type: String }
   };
 
+  static styles = css`
+    .player-container {
+      width: 100%;
+      height: 100%;
+    }
+  `;
+
   constructor() {
     super();
-    this.src = 'urn:rts:video:14318206';
+    this.mediaSrc = 'urn:rts:video:14318206';
     this.type = 'srgssr/urn';
   }
 
   render() {
+    // TODO Remove the player container once this is resolved: https://github.com/videojs/video.js/pull/8679
     return html`
       <style>${this.appliedCss}</style>
-      <video id="preview-player"
-             class="pillarbox-js"
-             controls crossOrigin="anonymous">
-      </video>
+      <div class="player-container">
+        <video id="preview-player"
+               class="pillarbox-js"
+               controls crossOrigin="anonymous">
+        </video>
+      </div>
     `;
   }
 
   updated(_changedProperties) {
     super.firstUpdated(_changedProperties);
 
-    if (['src', 'type'].some(property => _changedProperties.has(property))) {
+    if (['mediaSrc', 'type'].some(property => _changedProperties.has(property))) {
       this.player?.dispose();
 
       const el = this.shadowRoot.getElementById('preview-player');
@@ -52,7 +62,7 @@ class PreviewBox extends LitElement {
       });
 
       this.player.src({
-        src: this.src,
+        src: this.mediaSrc,
         type: this.type,
         disableTrackers: true
       });

--- a/src/components/toggle-pane-button.scss
+++ b/src/components/toggle-pane-button.scss
@@ -1,9 +1,9 @@
 :host {
   --button-background: #40729d;
   --button-hover-background: #305273;
-  --button-color: #fff;
+  --button-color: rgb(255 255 255 / 87%);
   --button-border-radius: 0.5em;
-  --popup-background: #333;
+  --popup-background: #242424;
   --popup-border: 1px solid #666;
   --popup-border-radius: 0.5em;
   --popup-z-index: 1;

--- a/src/components/tree-view.scss
+++ b/src/components/tree-view.scss
@@ -1,6 +1,6 @@
 :host {
-  --tree-background-color: #333;
-  --tree-item-hover-color: #555;
+  --tree-background-color: #242424;
+  --tree-item-hover-color: #444;
   --tree-item-selected-color: #666;
   --tree-folder-icon: '📁';
   --tree-file-icon: '📄';

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,6 @@ sourceInput.addEventListener('keyup', (event) => {
   const src = event.target.value;
 
   if (event.key === 'Enter' && src) {
-    preview.src = src;
+    preview.mediaSrc = src;
   }
 });

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ const navigationButton = document.getElementById('navigation-button');
 const editor = document.getElementById('editor');
 const preview = document.getElementById('preview');
 const downloadButton = document.getElementById('download');
+const sourceInput = document.getElementById('src-input');
 
 navigation.items = sassCompiler.workspace;
 navigationButton.label = currentItem.name;
@@ -31,3 +32,11 @@ editor.addEventListener('value-changed', (event) => {
 });
 
 downloadButton.addEventListener('click', () => sassCompiler.download());
+
+sourceInput.addEventListener('keyup', (event) => {
+  const src = event.target.value;
+
+  if (event.key === 'Enter' && src) {
+    preview.src = src;
+  }
+});

--- a/src/workspace/sass-workspace-compiler.js
+++ b/src/workspace/sass-workspace-compiler.js
@@ -55,12 +55,14 @@ export class SassWorkspaceCompiler {
   /**
    * Compiles the main SCSS file into CSS.
    *
+   * @param {Boolean} [compressed=true]  whether the output css will be compressed or not.
+   *
    * @returns {string} The compiled CSS.
    */
-  compile() {
+  compile(compressed = true) {
     const opts = {
       importer: this.#importer,
-      style: 'compressed'
+      style: compressed ? 'compressed' : 'expanded'
     };
 
     return sass.compileString(this.mainScss.content, opts).css;

--- a/src/workspace/workspace.js
+++ b/src/workspace/workspace.js
@@ -2,6 +2,14 @@ import pillarboxScssWorkspace from '../assets/pillarbox-scss-workspace.json';
 import videoJsStyle from 'video.js/dist/video-js.css?inline';
 import { SassWorkspaceCompiler } from './sass-workspace-compiler.js';
 
+/**
+ * Instance of `SassWorkspaceCompiler` dedicated to compiling the sass styles for pillarbox
+ *
+ * This setup includes the main Sass file (`pillarbox.scss`) that needs to be compiled along with
+ * additional static resources necessary for the compilation.
+ *
+ * @see SassWorkspaceCompiler
+ */
 export default new SassWorkspaceCompiler(
   pillarboxScssWorkspace,
   'pillarbox.scss',

--- a/test/components/preview-box.test.js
+++ b/test/components/preview-box.test.js
@@ -30,9 +30,12 @@ describe('PreviewBox Component', () => {
   it('initializes pillarbox with correct parameters', () => {
     const pillarboxMock = vi.mocked(pillarbox);
 
-    expect(pillarboxMock)
-      .toHaveBeenCalledWith(expect.anything(), { muted: true });
+    expect(pillarboxMock).toHaveBeenCalledWith(expect.anything(), {
+      muted: true,
+      restoreEl: true
+    });
     expect(pillarboxMock.mock.instances[0].srcSpy).toHaveBeenCalledWith({
+      disableTrackers: true,
       src: 'urn:rts:video:14318206',
       type: 'srgssr/urn'
     });


### PR DESCRIPTION
## Description

Resolved #7 by adding a new toggle pane button containing an input field for changing the current media of the player. Only URNs are accepted.

## Changes Made

- Disabled tracking for the preview player.
- Adds a parameter to `SassWorkspaceCompiler#compile` function to toggle the compression of the resulting css.
- Added a div container to ensure that the parent of the element passed to video.js is not the shadow root directly. This workaround resolves the issue until a permanent fix is implemented in video-js, see: https://github.com/videojs/video.js/pull/8679

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
