### PR TITLE
chore: update pillarbox to the latest verison

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pillarbox-web-theme-editor",
       "version": "0.0.0",
       "dependencies": {
-        "@srgssr/pillarbox-web": "^1.6.0",
+        "@srgssr/pillarbox-web": "^1.12.0",
         "jszip": "^3.10.1",
         "lit": "^3.1.2",
         "monaco-editor": "^0.47.0",
@@ -1637,12 +1637,12 @@
       "dev": true
     },
     "node_modules/@srgssr/pillarbox-web": {
-      "version": "1.6.0",
-      "resolved": "https://npm.pkg.github.com/download/@srgssr/pillarbox-web/1.6.0/8d58824aef896ce8945b38481b2e987cf97b251d",
-      "integrity": "sha512-E7PAkL2GphUEUkH+txvaIdOQNejSDS52AJpr1Y5yG0n2ggv7RuVAYox1PTlc2cSoy9UhG57wlhzOWgzDgQyM/A==",
+      "version": "1.12.0",
+      "resolved": "https://npm.pkg.github.com/download/@srgssr/pillarbox-web/1.12.0/c22e63101be3cd1ef7f2c1d1fd05f86fc49a04a2",
+      "integrity": "sha512-JbcFZUGFCUuhOq1gKbCLURISPn3mAxVI7b41VLiEhyWv+1MMXHx/sEnYsIr9xLBzy6OiktU42TiXrCHB08GP6A==",
       "license": "MIT",
       "dependencies": {
-        "video.js": "^8.11.1",
+        "video.js": "^8.11.8",
         "videojs-contrib-eme": "^3.11.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "preview": "vite preview --port 9696"
   },
   "dependencies": {
-    "@srgssr/pillarbox-web": "^1.6.0",
+    "@srgssr/pillarbox-web": "^1.12.0",
     "jszip": "^3.10.1",
     "lit": "^3.1.2",
     "monaco-editor": "^0.47.0",

--- a/vite.config.js
+++ b/vite.config.js
@@ -16,10 +16,6 @@ export default defineConfig({
       {
         find: /^monaco-editor$/,
         replacement: __dirname + '/node_modules/monaco-editor/esm/vs/editor/editor.api'
-      },
-      {
-        find: /^@srgssr\/pillarbox-web$/,
-        replacement: __dirname + '/node_modules/@srgssr/pillarbox-web/dist/pillarbox.es.js'
       }
     ]
   },


### PR DESCRIPTION
## Description

Updates pillarbox version  to `1.12.0`.

## Changes Made

- Removed the alias for `@srgssr/pillarbox-web` in the vitest configuration, as the package now includes an export clause in its package.json.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
