### PR TITLE
chore: add default media sources to theme editor input

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
           <input id="src-input" type="text" placeholder="Enter a URN..." list="default-options"/>
           <datalist id="default-options">
             <option value="urn:srf:video:c4927fcf-e1a0-0001-7edd-1ef01d441651">Live video</option>
-            <option value="urn:rts:video:3608506">live video (DVR)</option>
+            <option value="urn:rts:video:3608506">Live video (DVR)</option>
             <option value="urn:rts:video:14318206">Video</option>
             <option value="urn:rsi:audio:2108350">Audio</option>
             <option value="urn:rtr:audio:a029e818-77a5-4c2e-ad70-d573bb865e31">Live audio (DVR)</option>

--- a/index.html
+++ b/index.html
@@ -45,7 +45,14 @@
       <div class="section-title-container">
         <h2>Live Canvas Preview</h2>
         <toggle-pane-button title="Change the media" label="Change the media" id="load-media-button">
-          <input id="src-input" type="text" placeholder="Enter a URN..." />
+          <input id="src-input" type="text" placeholder="Enter a URN..." list="default-options"/>
+          <datalist id="default-options">
+            <option value="urn:srf:video:c4927fcf-e1a0-0001-7edd-1ef01d441651">Live video</option>
+            <option value="urn:rts:video:3608506">live video (DVR)</option>
+            <option value="urn:rts:video:14318206">Video</option>
+            <option value="urn:rsi:audio:2108350">Audio</option>
+            <option value="urn:rtr:audio:a029e818-77a5-4c2e-ad70-d573bb865e31">Live audio (DVR)</option>
+          </datalist>
         </toggle-pane-button>
       </div>
       <preview-box id="preview"></preview-box>


### PR DESCRIPTION
## Description

Resolve #9 by adding a pre-configured selection of default media sources to the theme editor's live preview section.

## Changes Made

The input field now includes a `datalist` element with default options for typical media scenarios. The `datalist` element was chosen to provide a simple and native solution for suggesting media sources, ensuring compatibility and ease of use across most browsers.

While Firefox has limited support for the `datalist` element, the decision to use it was made to simplify the implementation and utilize native HTML5 elements when possible. See the compatibility chart: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist

See the following comparison: 

| Chrome                                                                                                                          | Firefox                                                                                                                          | Safari                                                                                                                          |
|---------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
| ![Chrome Screenshot](https://github.com/SRGSSR/pillarbox-web-theme-editor/assets/11271371/ccdb73a5-58db-4b5f-a1a4-351a544afc1f) | ![Firefox Screenshot](https://github.com/SRGSSR/pillarbox-web-theme-editor/assets/11271371/920db20f-5112-40e3-83e4-0e2048a953ff) | ![Safari Screenshot](https://github.com/SRGSSR/pillarbox-web-theme-editor/assets/11271371/ed5045b6-d44d-4223-9136-aa2df9009b8e) |


## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
