### PR TITLE
chore: update pillarbox-web to 1.12.2

### DIFF
--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -17,11 +17,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 20
-          always-auth: true
-          registry-url: https://npm.pkg.github.com/
-          scope: '@srgssr'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
         env:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -21,11 +21,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 20
-          always-auth: true
-          registry-url: https://npm.pkg.github.com/
-          scope: '@srgssr'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
         if: github.event.action != 'closed'

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -18,11 +18,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 20
-          always-auth: true
-          registry-url: https://npm.pkg.github.com/
-          scope: '@srgssr'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
         env:

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,35 +25,25 @@ Ensure your system is equipped with:
 
 To get started with the Theme Editor on your local machine, follow these steps:
 
-1. Configure the `@srgssr` registry in your `.npmrc` file:
-
-    ```text
-    //npm.pkg.github.com/:_authToken=TOKEN
-    @srgssr:registry=https://npm.pkg.github.com
-    ```
-
-   Generate an authentication token by following this
-   guide: [Authenticating with a personal access token][git-auth-token].
-
-2. Clone the repository:
+1. Clone the repository:
 
     ```shell
     git clone https://github.com/SRGSSR/pillarbox-web-theme-editor.git
     ```
 
-3. Install dependencies:
+2. Install dependencies:
 
     ```shell
     npm install
     ```
 
-4. Launch the development server:
+3. Launch the development server:
 
     ```shell
     npm run start
     ```
 
-5. Navigate to `http://localhost:9696` in your browser.
+4. Navigate to `http://localhost:9696` in your browser.
 
    You'll be greeted by an intuitive interface featuring a CSS editor on the left and a live preview
    pane with a video player on the right, allowing for real-time theme customization.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pillarbox-web-theme-editor",
       "version": "0.0.0",
       "dependencies": {
-        "@srgssr/pillarbox-web": "^1.12.0",
+        "@srgssr/pillarbox-web": "^1.12.2",
         "jszip": "^3.10.1",
         "lit": "^3.1.2",
         "monaco-editor": "^0.47.0",
@@ -1637,10 +1637,9 @@
       "dev": true
     },
     "node_modules/@srgssr/pillarbox-web": {
-      "version": "1.12.0",
-      "resolved": "https://npm.pkg.github.com/download/@srgssr/pillarbox-web/1.12.0/c22e63101be3cd1ef7f2c1d1fd05f86fc49a04a2",
-      "integrity": "sha512-JbcFZUGFCUuhOq1gKbCLURISPn3mAxVI7b41VLiEhyWv+1MMXHx/sEnYsIr9xLBzy6OiktU42TiXrCHB08GP6A==",
-      "license": "MIT",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@srgssr/pillarbox-web/-/pillarbox-web-1.12.2.tgz",
+      "integrity": "sha512-DetyxIVre5RaSnWNsJRjir5qzur5tZ83NCkOB2bQ3qVr7PfL66vRDnke1ApueuPXtLfyUWSOBKVBZM1NUW6ZMA==",
       "dependencies": {
         "video.js": "^8.11.8",
         "videojs-contrib-eme": "^3.11.2"

--- a/package.json
+++ b/package.json
@@ -10,14 +10,14 @@
     "eslint": "eslint {src,test}/**/*.js",
     "eslint:fix": "eslint {src,test}/**/*.js --fix",
     "outdated": "npm outdated",
-    "start": "npm run prebuild && vite --port 9696",
+    "start": "npm run prebuild && vite --port 9696 --host --open",
     "stylelint": "stylelint {src,scss}/**/*.{css,scss,js}",
     "stylelint:fix": "stylelint {src,scss}/**/*.{css,scss,js} --fix",
     "prepare": "husky",
     "preview": "vite preview --port 9696"
   },
   "dependencies": {
-    "@srgssr/pillarbox-web": "^1.12.0",
+    "@srgssr/pillarbox-web": "^1.12.2",
     "jszip": "^3.10.1",
     "lit": "^3.1.2",
     "monaco-editor": "^0.47.0",


### PR DESCRIPTION
## Description

Update pillarbox to version 1.12.2. This version is now available on the public npm registry, replacing the previous version sourced from GitHub.

## Changes made

- Updated pillarbox version for the demo and samples.
- Adapted github actions.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
