### PR TITLE
fix(preview-box): default media URN

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
           <datalist id="default-options">
             <option value="urn:srf:video:c4927fcf-e1a0-0001-7edd-1ef01d441651">Live video</option>
             <option value="urn:rts:video:3608506">Live video (DVR)</option>
-            <option value="urn:rts:video:14318206">Video</option>
+            <option value="urn:swi:video:49122298">Video</option>
             <option value="urn:rsi:audio:2108350">Audio</option>
             <option value="urn:rtr:audio:a029e818-77a5-4c2e-ad70-d573bb865e31">Live audio (DVR)</option>
           </datalist>

--- a/src/components/preview-box.js
+++ b/src/components/preview-box.js
@@ -9,7 +9,7 @@ import pillarbox from '@srgssr/pillarbox-web';
  * @element preview-box
  *
  * @property {String} appliedCss CSS styles that can be applied to the video player.
- * @property {String} [src='urn:rts:video:14318206'] The media to be loaded by the player,
+ * @property {String} [src='urn:swi:video:49122298'] The media to be loaded by the player,
  * @property {String} [type='srgssr/urn'] The type of media to be loaded.
  *
  * @example
@@ -31,7 +31,7 @@ class PreviewBox extends LitElement {
 
   constructor() {
     super();
-    this.mediaSrc = 'urn:rts:video:14318206';
+    this.mediaSrc = 'urn:swi:video:49122298';
     this.type = 'srgssr/urn';
   }
 

--- a/test/components/preview-box.test.js
+++ b/test/components/preview-box.test.js
@@ -36,7 +36,7 @@ describe('PreviewBox Component', () => {
     });
     expect(pillarboxMock.mock.instances[0].srcSpy).toHaveBeenCalledWith({
       disableTrackers: true,
-      src: 'urn:rts:video:14318206',
+      src: 'urn:swi:video:49122298',
       type: 'srgssr/urn'
     });
   });


### PR DESCRIPTION
## Description

Change default value to avoid white background with BigPlayButton.

## Changes Made

- Use a URN with an appropriate background color and with subtitles
 
## Checklist

- [ ] I have followed the project's style and contribution guidelines.
- [ ] I have performed a self-review of my own changes.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
