### PR TITLE
docs: update urls for custom domain setup

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,8 +8,7 @@ video.js with additional functionalities. With this editor, you're equipped to d
 and generate themes that resonate with your unique brand identity, ensuring a cohesive and engaging
 user experience across your video content.
 
-Experience the latest version of the Theme Editor in action
-here: https://srgssr.github.io/pillarbox-web-theme-editor/
+Experience the latest version of the Theme Editor in action here: https://editor.pillarbox.ch
 
 ![Pillarbox-theme-editor](README-images/screenshot-theme-editor.png)
 


### PR DESCRIPTION
## Description

Use custom domain urls throughout the documentation.

## Changes Made

- Updated all URLs to the demo page to point to `demo.pillarbox.ch`
- Updated all API documentation URLs to point to `web.pillarbox.ch/api`
- Updated all URLs to the theme editor to point to `editor.pillarbox.ch`
- Updated all URLs to the web suite demo to point to `plugins.pillarbox.ch`
- Updated all URLs to the marketing page to point to `www.pillarbox.ch`
- Updated all URLs to the Android documentation page to point to `android.pillarbox.ch`

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
